### PR TITLE
Avoiding non-mainline GLFW releases to appear on downloads page

### DIFF
--- a/download.md
+++ b/download.md
@@ -3,7 +3,16 @@ layout: default
 title: Download
 ---
 
-{% for post in site.tags.changelog limit:1 %}
+{% comment %}Getting a list of all posts tagged changelog, sorted from newest to oldest{% endcomment %}
+{% for post in site.tags.changelog %}
+
+{% comment %}Getting first character of post title (Version string){% endcomment %}
+{% capture major_version_string %}
+{{ post.title | substring: 0, 1 }}
+{% endcapture %}
+
+{% comment %}Providing links to the latest mainline GLFW release{% endcomment %}
+{% if major_version_string contains '3' %}
 
 ## Download
 
@@ -54,4 +63,6 @@ This contains:
 The latest version of the 3.0 source code is always available in our
 [Git repository](https://github.com/glfw/glfw).
 
+{% break %}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
Previous code was always looking for latest post tagged `changelog` title to update and provide download links on downloads page. This commit fixes a bug resulting non-mainline GLFW 2.x bug fix releases to appear on downloads page, by forcing mainline GLFW 3.x releases to only show up.

Current code looks for latest post tagged as `changelog` which its title first character contains 3. Whenever GLFW reaches 4.x series, it should be changed to compare the first character with 4; And whenever GLFW major version string contains more than one character (GLFW 10.x), it should be changed to return first 2 characters of post title and compare it with 10.

And Happy GLFW 3.0 release :smile: 
