### PR TITLE
Updated download links to link to packages hosted on GitHub.

### DIFF
--- a/download.md
+++ b/download.md
@@ -24,7 +24,7 @@ The latest version of the source code, including tags for all releases,
 is always available in our Git repository.
 {% endcol %}
 {% col 1-3 %}
-{% button http://sourceforge.net/projects/glfw/files/glfw/{{ glfwversion }}/glfw-{{ glfwversion }}.zip/download %}
+{% button https://github.com/glfw/glfw/releases/download/{{ glfwversion }}/glfw-{{ glfwversion }}.zip %}
 Source package
 {% endbutton %}
 {% button https://github.com/glfw/glfw %}
@@ -42,10 +42,10 @@ These packages contain complete GLFW header file,
 library binaries for Visual C++ 2012, Visual C++ 2013 and MinGW / MinGW-w64.
 {% endcol %}
 {% col 1-3 %}
-{% button http://sourceforge.net/projects/glfw/files/glfw/{{ glfwversion }}/glfw-{{ glfwversion }}.bin.WIN32.zip/download %}
+{% button https://github.com/glfw/glfw/releases/download/{{ glfwversion }}/glfw-{{ glfwversion }}.bin.WIN32.zip %}
 32-bit Windows binaries
 {% endbutton %}
-{% button http://sourceforge.net/projects/glfw/files/glfw/{{ glfwversion }}/glfw-{{ glfwversion }}.bin.WIN64.zip/download %}
+{% button https://github.com/glfw/glfw/releases/download/{{ glfwversion }}/glfw-{{ glfwversion }}.bin.WIN64.zip %}
 64-bit Windows binaries
 {% endbutton %}
 {% endcol %}

--- a/index.md
+++ b/index.md
@@ -22,7 +22,7 @@ GLFW is licensed under the [zlib/libpng license](license.html).
 
 {% col 1-3 %}
 
-{% button http://sourceforge.net/projects/glfw/files/glfw/{{ glfwversion }}/glfw-{{ glfwversion }}.zip/download %}
+{% button https://github.com/glfw/glfw/releases/download/{{ glfwversion }}/glfw-{{ glfwversion }}.zip %}
 Download GLFW {{ glfwversion }}
 <br>
 <small>Released on {% include time.html date=releasedate %}</small>


### PR DESCRIPTION
Here is the updated download links awaiting GLFW 3.1 release to address glfw/glfw#273 issue.